### PR TITLE
Configure TypeScript Paths

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App.tsx';
-import './index.css';
+import App from '@/App.tsx';
+import '@/index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,11 @@
     "module": "ESNext",
     "skipLibCheck": true,
 
+     /*Configure TypeScript Paths*/
+      "paths": {
+        "@/*": ["./src/*"],
+      },
+
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,9 @@
 
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
-// https://vitejs.dev/config/
+// vite.config.ts
 export default defineConfig({
   plugins: [react()],
   server: {
@@ -16,5 +17,15 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/__test__/setupTests.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  build: {
+    rollupOptions: {
+      external: ['src/App.tsx'],
+    },
   },
 });


### PR DESCRIPTION
### What does this PR do?

This PR sets up a new React project  path aliases for TypeScript in a React project using Vite, making imports cleaner and more manageable for efficient development.
### Description of Task to be Completed?
- [x] Set up path aliases in the TypeScript configuration file (tsconfig.json).
- [x]Define aliases for commonly used directories or modules to simplify import statements.
